### PR TITLE
fix: Remove eslint deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
   "author": "Ives van Hoorne",
   "license": "MIT",
   "devDependencies": {
-    "serve": "^11.2.0",
-    "babel-eslint": "^10.1.0",
-    "eslint": "^7.2.0"
+    "serve": "^11.2.0"
   }
 }


### PR DESCRIPTION
No linting in V2 and this ensures no conflicts in the Sandbox Migration template. The Sandbox migration template has Eslint installed